### PR TITLE
fix: 본문 이미지 max-width 스타일 추가

### DIFF
--- a/src/css/main/article/index-page.css
+++ b/src/css/main/article/index-page.css
@@ -31,6 +31,11 @@
 .article-thumbnail-shape-circle {
   border-radius: 100%;
 }
+
+#article-container #article-wrapper img  {
+  max-width: 100%;
+}
+
 #article-container #article-wrapper .image-wrapper img {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
**Problem**
- 본문 이미지 width가 #article-wrapper 보다 width가 큰 경우 이미지가 #article-wapper밖으로 나가는 문제 (문제 발생 캡쳐본 아래에 첨부합니다.)

![max-width](https://user-images.githubusercontent.com/23207057/185450090-20b05036-9846-4cca-b520-94078269502e.PNG)